### PR TITLE
v2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
   - `sendData`: return `Object?` (instead of `dynamic`).
 
 - swiss_knife: ^3.3.0
-- http: ^1.3.0
+- web: ^1.1.0
+- js_interop_utils: ^1.0.6
 
 ## 2.2.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 2.3.0
+
+- Change use of `dart:html` to package `web`.
+
+- `HttpRequest`:
+  - `sendData`: return `Object?` (instead of `dynamic`).
+
+- swiss_knife: ^3.3.0
+- http: ^1.3.0
+
 ## 2.2.5
 
 - `HttpClient`:

--- a/lib/src/http_client.dart
+++ b/lib/src/http_client.dart
@@ -9,8 +9,8 @@ import 'package:swiss_knife/swiss_knife.dart';
 
 import 'http_client_extension.dart';
 import 'http_client_none.dart'
-    if (dart.library.html) 'http_client_browser.dart'
-    if (dart.library.io) 'http_client_io.dart';
+    if (dart.library.io) 'http_client_io.dart'
+    if (dart.library.js_interop) 'http_client_browser.dart';
 
 typedef ResponseHeaderGetter = String? Function(String headerKey);
 
@@ -1354,7 +1354,7 @@ class HttpRequest {
   }
 
   /// Data/body to send with the request.
-  dynamic get sendData => _sendData;
+  Object? get sendData => _sendData;
 
   /// [sendData] length in bytes.
   int? get sendDataLength => _sendDataLength();

--- a/lib/src/http_client_browser.dart
+++ b/lib/src/http_client_browser.dart
@@ -212,6 +212,7 @@ class HttpClientRequesterBrowser extends HttpClientRequester {
       var event = error as web.Event;
       return '{type: ${event.type} ; target: ${event.target} ; error: $event}';
     }
+
     return '$error';
   }
 

--- a/lib/src/http_client_browser.dart
+++ b/lib/src/http_client_browser.dart
@@ -1,10 +1,10 @@
 import 'dart:async';
-// ignore: deprecated_member_use
-import 'dart:html' as browser;
 import 'dart:typed_data';
 
 import 'package:collection/collection.dart';
+import 'package:js_interop_utils/js_interop_utils.dart';
 import 'package:swiss_knife/swiss_knife.dart';
+import 'package:web/web.dart' as web;
 
 import 'http_client.dart';
 import 'http_client_extension.dart';
@@ -45,31 +45,29 @@ class HttpClientRequesterBrowser extends HttpClientRequester {
   bool setupUserAgent(String? userAgent) => false;
 
   @override
-  void stdout(Object? o) => browser.window.console.log(o);
+  void stdout(Object? o) => web.console.log(o?.jsify());
 
   @override
-  void stderr(Object? o) => browser.window.console.error(o);
+  void stderr(Object? o) => web.console.error(o?.jsify());
 
   @override
   Future<HttpResponse> doHttpRequest(HttpClient client, HttpRequest request,
       ProgressListener? progressListener, bool log) {
-    var completer = Completer<HttpResponse>();
-
-    var xhr = browser.HttpRequest();
-    xhr.responseType = 'arraybuffer';
-
     var methodName = getHttpMethodName(request.method, HttpMethod.GET)!;
-
     assert(RegExp(r'^(?:GET|OPTIONS|POST|PUT|DELETE|PATCH|HEAD)$')
         .hasMatch(methodName));
 
     var url = request.requestURL;
-
     if (log) {
       this.log('REQUEST: $request > URI: $url');
     }
 
-    xhr.open(methodName, url, async: true);
+    var completer = Completer<HttpResponse>();
+
+    var xhr = web.XMLHttpRequest();
+    xhr.responseType = 'arraybuffer';
+
+    xhr.open(methodName, url, true);
 
     xhr.withCredentials = request.withCredentials;
 
@@ -81,18 +79,23 @@ class HttpClientRequesterBrowser extends HttpClientRequester {
       xhr.overrideMimeType(request.mimeType!);
     }
 
-    if (request.requestHeaders != null) {
-      request.requestHeaders!.forEach((header, value) {
+    var requestHeaders = request.requestHeaders;
+    if (requestHeaders != null) {
+      for (var e in requestHeaders.entries) {
+        var header = e.key;
         if (!_isForbiddenRequestHeader(header)) {
           try {
-            xhr.setRequestHeader(header, value);
+            xhr.setRequestHeader(header, e.value);
           } catch (_) {}
         }
-      });
+      }
     }
 
     if (progressListener != null) {
-      xhr.upload.onProgress.listen((e) {
+      var uploadOnProgress =
+          web.EventStreamProviders.progressEvent.forTarget(xhr.upload);
+
+      uploadOnProgress.listen((e) {
         try {
           progressListener(request, e.loaded, e.total, _calcLoadRatio(e), true);
         } catch (e, s) {
@@ -123,7 +126,7 @@ class HttpClientRequesterBrowser extends HttpClientRequester {
         }
       }
 
-      var status = xhr.status ?? 0;
+      var status = xhr.status;
 
       var accepted = status >= 200 && status < 300;
       var fileUri = status == 0; // file:// URIs have status of 0.
@@ -147,8 +150,9 @@ class HttpClientRequesterBrowser extends HttpClientRequester {
           logError('REQUEST: $request > status: ${xhr.status}', e);
         }
 
+        var errorBody = HttpBody.from(xhr.response?.dartify());
         _completeOnError(completer, client, request, progressListener, log,
-            status, HttpBody.from(xhr.response)?.asString, e);
+            status, errorBody?.asString, e);
       }
     });
 
@@ -156,12 +160,13 @@ class HttpClientRequesterBrowser extends HttpClientRequester {
       if (log) {
         logError('REQUEST: $request > status: ${xhr.status}', e);
       }
+      var errorResponse = HttpBody.from(xhr.response?.dartify());
       _completeOnError(completer, client, request, progressListener, log,
-          xhr.status ?? 0, HttpBody.from(xhr.response)?.asString, e);
+          xhr.status, errorResponse?.asString, e);
     });
 
     if (request.sendData != null) {
-      xhr.send(request.sendData);
+      xhr.send(request.sendData?.jsify());
     } else {
       xhr.send();
     }
@@ -169,8 +174,7 @@ class HttpClientRequesterBrowser extends HttpClientRequester {
     return completer.future;
   }
 
-  double? _calcLoadRatio(browser.ProgressEvent e) =>
-      e.loaded == null || e.total == null ? null : e.loaded! / e.total!;
+  double? _calcLoadRatio(web.ProgressEvent e) => e.loaded / e.total;
 
   void _completeOnError(
       Completer<HttpResponse> originalRequestCompleter,
@@ -200,11 +204,13 @@ class HttpClientRequesterBrowser extends HttpClientRequester {
     }
   }
 
-  String _errorToString(dynamic error) {
+  String _errorToString(Object? error) {
     if (error == null) return '';
     if (error is String) return error;
-    if (error is browser.Event) {
-      return '{type: ${error.type} ; target: ${error.target} ; error: $error}';
+
+    if (error.asJSAny.isA<web.Event>()) {
+      var event = error as web.Event;
+      return '{type: ${event.type} ; target: ${event.target} ; error: $event}';
     }
     return '$error';
   }
@@ -310,10 +316,10 @@ class HttpClientRequesterBrowser extends HttpClientRequester {
   }
 
   HttpResponse _processResponse(HttpClient client, HttpRequest request,
-      HttpMethod method, String url, browser.HttpRequest xhr) {
+      HttpMethod method, String url, web.XMLHttpRequest xhr) {
     var contentType = xhr.getResponseHeader('Content-Type');
-    var status = xhr.status ?? 0;
-    var body = xhr.response;
+    var status = xhr.status;
+    var body = xhr.response?.dartify();
     var irrelevantContent = (status >= 300 && status < 600);
 
     if (status == 204) {
@@ -328,8 +334,7 @@ class HttpClientRequesterBrowser extends HttpClientRequester {
       httpBody = HttpBody.from(null, MimeType.parse(contentType));
     }
 
-    var response = HttpResponse(
-        method, url, xhr.responseUrl ?? url, status, httpBody,
+    var response = HttpResponse(method, url, xhr.responseURL, status, httpBody,
         responseHeaderGetter: (key) => xhr.getResponseHeader(key),
         request: xhr,
         jsonDecoder: client.jsonDecoder);
@@ -363,11 +368,11 @@ HttpClientRequester createHttpClientRequesterImpl() {
 }
 
 Uri getHttpClientRuntimeUriImpl() {
-  var href = Uri.parse(browser.window.location.href);
+  var href = Uri.parse(web.window.location.href);
   return href;
 }
 
-class HttpBlobBrowser extends HttpBlob<browser.Blob> {
+class HttpBlobBrowser extends HttpBlob<web.Blob> {
   HttpBlobBrowser(super.blob, super.mimeType);
 
   @override
@@ -377,21 +382,39 @@ class HttpBlobBrowser extends HttpBlob<browser.Blob> {
   Future<ByteBuffer> readByteBuffer() {
     var completer = Completer<ByteBuffer>();
 
-    var reader = browser.FileReader();
+    var reader = web.FileReader();
 
     reader.onLoadEnd.listen((e) {
       var result = reader.result;
 
       ByteBuffer? data;
-      if (result is ByteBuffer) {
-        data = result;
-      } else if (result is String) {
-        data = result.toByteBuffer(encoding: mimeType?.preferredStringEncoding);
-      } else if (result is List<int>) {
-        if (result is TypedData) {
-          data = (result as TypedData).buffer;
+      if (result.isA<JSArrayBuffer>()) {
+        data = (result as JSArrayBuffer).toDart;
+      } else if (result.isA<JSString>()) {
+        data = (result as JSString)
+            .toDart
+            .toByteBuffer(encoding: mimeType?.preferredStringEncoding);
+      } else if (result.isA<JSArray>()) {
+        if (result.isA<JSUint8Array>()) {
+          data = (result as JSUint8Array).toDart.buffer;
+        } else if (result.isA<JSInt8Array>()) {
+          data = (result as JSInt8Array).toDart.buffer;
+        } else if (result.isA<JSUint8ClampedArray>()) {
+          data = (result as JSUint8ClampedArray).toDart.buffer;
+        } else if (result.isA<JSArray<JSNumber>>()) {
+          data = Uint8List.fromList((result as JSArray<JSNumber>)
+                  .toDart
+                  .map((e) => e.toDartInt)
+                  .toList())
+              .buffer;
         } else {
-          data = Uint8List.fromList(result).buffer;
+          data = Uint8List.fromList((result as JSArray)
+                  .toDart
+                  .map((e) =>
+                      e.isA<JSNumber>() ? (e as JSNumber).toDartInt : null)
+                  .nonNulls
+                  .toList())
+              .buffer;
         }
       }
       completer.complete(data);
@@ -406,9 +429,19 @@ class HttpBlobBrowser extends HttpBlob<browser.Blob> {
 HttpBlob? createHttpBlobImpl(Object? content, MimeType? mimeType) {
   if (content == null) return null;
   if (content is HttpBlob) return content;
-  if (content is browser.Blob) return HttpBlobBrowser(content, mimeType);
-  var blob = browser.Blob([content], mimeType.toString());
+
+  var jsAny = content.asJSAny;
+  if (jsAny == null) return null;
+
+  if (jsAny.isA<web.Blob>()) {
+    return HttpBlobBrowser(jsAny as web.Blob, mimeType);
+  }
+
+  var blob = mimeType != null
+      ? web.Blob([jsAny].toJS, web.BlobPropertyBag(type: mimeType.toString()))
+      : web.Blob([jsAny].toJS);
+
   return HttpBlobBrowser(blob, mimeType);
 }
 
-bool isHttpBlobImpl(Object? o) => o is HttpBlob || o is browser.Blob;
+bool isHttpBlobImpl(Object? o) => o is HttpBlob || o.asJSAny.isA<web.Blob>();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,16 +1,19 @@
 name: mercury_client
 description: Portable HTTP client (Browser and Native support) with memory cache and support for methods GET, HEAD, POST, PUT, DELETE, PATCH and OPTIONS.
 
-version: 2.2.5
+version: 2.3.0
 homepage: https://github.com/gmpassos/mercury_client
 
 environment:
   sdk: '>=3.6.0 <4.0.0'
 
 dependencies:
-  swiss_knife: ^3.2.3
+  swiss_knife: ^3.3.0
   collection: ^1.19.0
   charset: ^2.0.1
+  http: ^1.3.0
+  web: ^1.1.0
+  js_interop_utils: ^1.0.6
 
 dev_dependencies:
   lints: ^5.1.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,6 @@ dependencies:
   swiss_knife: ^3.3.0
   collection: ^1.19.0
   charset: ^2.0.1
-  http: ^1.3.0
   web: ^1.1.0
   js_interop_utils: ^1.0.6
 

--- a/test/mercury_client_basic.dart
+++ b/test/mercury_client_basic.dart
@@ -121,7 +121,8 @@ void doBasicTests(TestServerChannel testServerChannel) {
               144,
               33
             ]));
-        expect(latin1.decode(request.sendData), equals('char utf-8: Ä!'));
+        expect(latin1.decode(request.sendData as List<int>),
+            equals('char utf-8: Ä!'));
         expect(request.sendDataLength, equals(15));
         expect(request.sendDataAsString, 'char utf-8: Đ!');
         expect(request.sendDataAsString!.length, equals(14));
@@ -216,6 +217,8 @@ void doBasicTests(TestServerChannel testServerChannel) {
           progressListener: (request, loaded, total, ratio, upload) {
         progress.add('${upload ? 'upload' : 'download'}[$loaded/$total]');
       });
+
+      print('!!! response: $response');
 
       expect(response.isOK, isTrue);
       expect(response.isNotOK, isFalse);

--- a/test/mercury_client_basic.dart
+++ b/test/mercury_client_basic.dart
@@ -218,8 +218,6 @@ void doBasicTests(TestServerChannel testServerChannel) {
         progress.add('${upload ? 'upload' : 'download'}[$loaded/$total]');
       });
 
-      print('!!! response: $response');
-
       expect(response.isOK, isTrue);
       expect(response.isNotOK, isFalse);
       expect(response.isError, isFalse);

--- a/test/mercury_client_basic_browser_test.dart
+++ b/test/mercury_client_basic_browser_test.dart
@@ -77,7 +77,8 @@ class BrowserTestServerChannel implements TestServerChannel {
     print('[BROWSER] WAIT OPEN');
 
     send('wait');
-    _serverPort = await receive(-1);
+    var port = await receive<num>(-1);
+    _serverPort = port.toInt();
     return true;
   }
 


### PR DESCRIPTION
- Change use of `dart:html` to package `web`.

- `HttpRequest`:
  - `sendData`: return `Object?` (instead of `dynamic`).

- swiss_knife: ^3.3.0
- http: ^1.3.0